### PR TITLE
Fix position of the menu for rtl languages.

### DIFF
--- a/duolingo-course-switcher.user.js
+++ b/duolingo-course-switcher.user.js
@@ -10,7 +10,8 @@
 
 document.head.appendChild($('<style type="text/css">'+
     '.choice span:nth-child(2) {text-transform: capitalize;}'+
-    '.language-sub-courses {position:absolute; top:-28px !important; left:200px !important; color:#000; background-color: #fff; min-width: 150px; min-height: 50px; display: none !important;}'+
+    '.language-sub-courses {position:absolute; top:-28px !important; color:#000; background-color: #fff; min-width: 150px; min-height: 50px; display: none !important;}'+
+    'html[dir="ltr"] .language-sub-courses {left:200px !important;} html[dir="rtl"] .language-sub-courses {right:200px !important;}'+
     '</style>').get(0));
 
 var header1 = JSON.parse('{"dn": "van", "sv": "fr\\u00e5n", "fr": "de", "hu": "-b\\u00f3l", "eo": "de", "tr": "-den", "es": "desde", "ro": "din", "ja": "\\u304b\\u3089", "vi": "t\\u1eeb", "it": "da", "he": "\\u05de", "el": "\\u03b1\\u03c0\\u03cc", "ru": "\\u0441", "ar": "\\u0645\\u0646", "en": "from", "ga": "\\u00f3", "cs": "od", "pt": "de", "de": "von", "zs": "\\u5f9e", "pl": "z"}');


### PR DESCRIPTION
The submenus are not displayed correctly when the direction of the interface language is right-to-left (for instance Arabic). This commit fixes this problem.
